### PR TITLE
Fix: Branching workflow database field error

### DIFF
--- a/src/app/api/ideas/route.ts
+++ b/src/app/api/ideas/route.ts
@@ -54,24 +54,18 @@ export async function POST(req: Request) {
       // Continue without embedding
     }
     
+    // Fix: Use direct column names instead of metadata field
     const ideaData: any = {
       user_id: user.id,
       title,
       content,
       category,
       embedding,
-      development_count: isBranch ? 1 : 0
-    }
-    
-    // Add branching fields if provided
-    if (branchedFromId) {
-      ideaData.branched_from_id = branchedFromId
-      // Store branch note in metadata since branch_note column doesn't exist
-      ideaData.metadata = {
-        ...(ideaData.metadata || {}),
-        branch_note: branchNote,
-        is_branch: true
-      }
+      development_count: isBranch ? 1 : 0,
+      // Add branching fields directly as columns
+      branched_from_id: branchedFromId || null,
+      branch_note: branchNote || null,
+      is_branch: isBranch || false
     }
     
     const { data: newIdea, error: createError } = await supabase


### PR DESCRIPTION
## 🐛 Bug Fix: Branching Workflow

### Problem
The idea branching workflow was failing with error: "Failed to save idea: Failed to create branched idea"

### Root Cause
The API was attempting to store branching information (`branch_note`, `is_branch`) in a non-existent `metadata` JSON field, when these are actually direct columns in the database.

### Solution
- Updated `/api/ideas/route.ts` to use the correct database columns directly
- Removed the metadata field assignment
- Added proper null handling for optional branching fields

### Changes Made
```typescript
// Before (broken):
ideaData.metadata = {
  branch_note: branchNote,
  is_branch: true
}

// After (fixed):
const ideaData: any = {
  // ... other fields
  branched_from_id: branchedFromId || null,
  branch_note: branchNote || null,
  is_branch: isBranch || false
}
```

### Testing Instructions
1. Go to the app and create a new idea
2. Save it successfully
3. Open the idea from the gallery
4. Try to create a branch/variation
5. Verify it saves without errors

This fix ensures the branching workflow works correctly by using the actual database schema.