### PR TITLE
Update Claude workflow documentation for better context retention

### DIFF
--- a/.claude-project
+++ b/.claude-project
@@ -1,0 +1,39 @@
+# CRITICAL: Read This First - Poppy Idea Engine
+
+## Repository Details
+- **Repository**: Cbiz17/poppy-idea-engine
+- **Owner**: Cbiz17 (NOT cbikis or any other variation)
+- **Production URL**: poppy-idea-engine.vercel.app
+
+## Workflow Rules - MANDATORY
+
+### 1. NEVER Test Locally
+- No `npm run dev` on local machine
+- No localhost testing
+- ONLY use Vercel preview deployments
+
+### 2. Branch Strategy
+- NEVER commit directly to main
+- Create feature branches for EVERYTHING
+- Branch names: fix/issue-name, feature/feature-name, update/what-updating
+
+### 3. Deployment Process
+1. Create branch
+2. Push changes
+3. Vercel automatically creates preview: poppy-idea-engine-[branch]-cbiz17.vercel.app
+4. Test in preview URL
+5. Only merge after testing passes
+
+### 4. Database Reminders
+- Database has specific columns - always check schema
+- Ideas table has: branch_note, is_branch, branched_from_id
+- NO metadata column exists in ideas table
+
+## Quick Reference
+- Full preferences: .claude/preferences.md
+- Project docs: docs/
+- When in doubt, create a branch and test in preview
+
+## GitHub Token
+- Will be provided in chat when needed
+- Always ask if not provided

--- a/.claude/preferences.md
+++ b/.claude/preferences.md
@@ -1,5 +1,39 @@
 # Claude Preferences for This Project
 
+## CRITICAL: GitHub & Deployment Workflow
+
+### GitHub Access
+- **Repository**: `Cbiz17/poppy-idea-engine` (NOT cbikis/idea-engine)
+- **Owner**: Cbiz17 (NOT cbikis)
+- **Note**: GitHub token will be provided in chat when needed
+
+### Deployment Workflow - NEVER TEST LOCALLY
+1. **ALWAYS create a new branch** for ANY changes
+2. **Push to branch** → Vercel creates preview deployment automatically
+3. **Test in Vercel preview URL** (format: `poppy-idea-engine-[branch-name]-cbiz17.vercel.app`)
+4. **Only merge to main** AFTER testing passes in preview
+5. **Production URL**: `poppy-idea-engine.vercel.app` (main branch only)
+
+### Branch Strategy
+- **NEVER commit directly to main branch**
+- Create descriptive branch names: `fix/bug-name`, `feature/feature-name`, `update/what-updating`
+- Wait for preview deployment before creating PR
+- Get approval before merging to main
+
+## Project-Specific Context
+
+### Database (Supabase)
+- **Check actual schema** - don't assume column names
+- Common tables: `ideas`, `profiles`, `conversations`, `conversation_messages`
+- Branching columns exist: `branch_note`, `is_branch`, `branched_from_id`
+- NO `metadata` column in ideas table
+
+### Common Pitfalls to Avoid
+- Don't assume database columns - check the schema
+- Don't merge PRs immediately - wait for testing
+- Don't test on local machine - use Vercel previews only
+- Don't forget to ask for GitHub token when accessing repos
+
 ## Code Generation Preferences
 
 **IMPORTANT**: For this project, avoid using artifacts unless specifically requested.
@@ -19,9 +53,12 @@ Only use artifacts when:
 - Keep changes focused and surgical
 - Don't break working functionality
 - Add debugging before making big changes
-- Test incrementally
+- Test incrementally in Vercel previews
+- Create PRs with clear descriptions of changes and testing instructions
 
 ## Communication Style
 - Be direct and concise
 - Explain changes simply
 - Ask before making major architectural changes
+- Always mention the preview URL when pushing changes
+- Remind about testing in preview before merging

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ Showing exactly how AI improves - building trust for family-level AI decisions.
 ### 4. Personal Context System
 Learning preferences and patterns - foundation for multi-family member understanding.
 
+## 🔄 Development Workflow
+
+### Branch & Deploy Strategy
+1. **Never commit to main** - always create feature branches
+2. **Automatic preview deployments** - every branch gets its own Vercel URL
+3. **Test in preview** - format: `poppy-idea-engine-[branch-name]-cbiz17.vercel.app`
+4. **Merge only after testing** - ensure preview works before merging to production
+
+### For AI Assistants (Claude)
+- Repository: `Cbiz17/poppy-idea-engine` (not cbikis)
+- See `.claude/preferences.md` for complete workflow instructions
+- Never test locally - always use Vercel previews
+
 ## 🤝 Contributing
 
 **Read first**: [Contributing Guidelines](./CONTRIBUTING.md)


### PR DESCRIPTION
## 📝 Update Claude Workflow Documentation

This PR updates documentation to make it easier for Claude (and other AI assistants) to understand the correct workflow without needing reminders every chat session.

### Changes Made

1. **Updated `.claude/preferences.md`**
   - Added GitHub repository details (Cbiz17/poppy-idea-engine)
   - Emphasized Vercel preview deployment workflow
   - Added database schema reminders
   - Included common pitfalls to avoid
   - Clarified branch strategy and testing process

2. **Updated `README.md`**
   - Added "Development Workflow" section
   - Clear branch & deploy strategy
   - Note for AI assistants about repository details

3. **Created `.claude-project` file**
   - Critical workflow rules at root level for immediate visibility
   - Emphasizes no local testing rule
   - Quick reference format

### Why These Changes Matter

These updates should eliminate the need to:
- Remind Claude of the GitHub repository name
- Provide the GitHub token every time
- Explain not to test locally
- Clarify the Vercel preview workflow

### Testing
This is a documentation-only change, so no functional testing needed.

### Preview URL
Once deployed, check the preview to ensure all files are properly formatted.