### PR TITLE
Fix: Undefined title when saving ideas

### DIFF
--- a/src/utils/ideaProcessing.ts
+++ b/src/utils/ideaProcessing.ts
@@ -51,15 +51,30 @@ Please respond with ONLY a JSON object in this exact format:
       fullResponse += decoder.decode()
     }
 
+    // Clean the response to extract JSON
+    // The AI might return the JSON with some extra text, so we need to extract just the JSON part
+    const jsonMatch = fullResponse.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      console.warn('No JSON found in AI response:', fullResponse)
+      throw new Error('No valid JSON in AI response')
+    }
+
     try {
-      const parsed = JSON.parse(fullResponse.trim())
+      const parsed = JSON.parse(jsonMatch[0])
+      
+      // Validate the parsed data
+      if (!parsed.title || !parsed.content || !parsed.category) {
+        console.warn('Incomplete AI response:', parsed)
+        throw new Error('Incomplete AI response')
+      }
+      
       return {
-        title: parsed.title || "New Idea",
-        content: parsed.content || "No summary available",
-        category: parsed.category || "General"
+        title: parsed.title,
+        content: parsed.content,
+        category: parsed.category
       }
     } catch (parseError) {
-      console.warn('Failed to parse AI response as JSON:', fullResponse)
+      console.warn('Failed to parse AI response as JSON:', jsonMatch[0])
       throw new Error('Invalid AI response format')
     }
   } catch (error) {


### PR DESCRIPTION
## 🐛 Fix: Undefined Title When Saving Ideas

### Problem
When saving ideas through the AI-powered save modal, the title was showing as "undefined + undefined". This was happening because the AI response (which includes JSON) wasn't being parsed correctly from the streaming response.

### Root Cause
The `/api/chat-enhanced` endpoint returns a streaming response, but the JSON object might be embedded within other text. The original code was trying to parse the entire response as JSON, which would fail if there was any extra text.

### Solution
- Improved JSON extraction using regex to find the JSON object within the response
- Added validation to ensure all required fields (title, content, category) are present
- Better error handling with fallback to the existing fallback processing

### Changes Made
```javascript
// Before: Direct parsing that could fail
const parsed = JSON.parse(fullResponse.trim())

// After: Extract JSON from response first
const jsonMatch = fullResponse.match(/\{[\s\S]*\}/)
if (!jsonMatch) {
  throw new Error('No valid JSON in AI response')
}
const parsed = JSON.parse(jsonMatch[0])
```

### Testing
1. Create a new conversation
2. Save an idea using the save button
3. Verify the title is properly generated (not "undefined + undefined")

### Preview URL
https://poppy-idea-engine-fix-undefined-title-bug-cbiz17.vercel.app