### PR TITLE
Fix: Remove distracting save button in idea development mode

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -206,10 +206,17 @@ export default function ChatInterface({ user }: ChatInterfaceProps) {
     )
     setHasValueableContent(hasValuable)
     
-    if (messages.length > 3 && hasValuable) {
+    // Only show floating save button if:
+    // 1. There's valuable content
+    // 2. More than 3 messages
+    // 3. NOT in idea development mode (no currentIdeaContext)
+    // 4. NOT already detected as a continuation
+    if (messages.length > 3 && hasValuable && !currentIdeaContext && !continuationContext) {
       setShowFloatingSave(true)
+    } else {
+      setShowFloatingSave(false)
     }
-  }, [messages])
+  }, [messages, currentIdeaContext, continuationContext])
 
   // Smart continuation detection
   useEffect(() => {


### PR DESCRIPTION
## 🎯 Fix: Remove Distracting Save Button in Idea Development Mode

### Problem
When users are developing an existing idea (accessed from the Ideas Gallery), a pulsating "Save idea" button appears. This is:
- **Distracting** - The pulsating animation draws attention away from the conversation
- **Confusing** - Users are already working on a saved idea, so "Save idea" doesn't make sense
- **Redundant** - The update/branch options are already shown at the bottom of the chat

### Solution
Updated the logic that controls when the floating save button appears. Now it will:
- ✅ **Only show for new conversations** (no currentIdeaContext)
- ✅ **Hide when developing existing ideas** (has currentIdeaContext)
- ✅ **Hide when a continuation is detected** (has continuationContext)

### Changes Made
```javascript
// Before: Only checked for valuable content and message count
if (messages.length > 3 && hasValuable) {
  setShowFloatingSave(true)
}

// After: Also checks if we're in idea development mode
if (messages.length > 3 && hasValuable && !currentIdeaContext && !continuationContext) {
  setShowFloatingSave(true)
} else {
  setShowFloatingSave(false)
}
```

### User Experience
- When starting a new conversation → Save button appears when there's valuable content
- When developing an existing idea → No distracting save button, just the update/branch UI
- Cleaner, more focused interface for idea development

### Testing
1. Start a new conversation - save button should appear after valuable content
2. Go to Ideas Gallery and develop an idea - save button should NOT appear
3. The update/branch UI at the bottom should be the only save option

### Preview URL
https://poppy-idea-engine-fix-remove-distracting-save-button-cbiz17.vercel.app